### PR TITLE
[APPAI-1288] Ignoring test packages for destination node for maven ecosystem

### DIFF
--- a/f8a_utils/dependency_finder.py
+++ b/f8a_utils/dependency_finder.py
@@ -45,7 +45,7 @@ class DependencyFinder():
                     line = line.replace(' ;', '')
                     prefix, suffix = line.strip().split(" -> ")
                     parsed_json = DependencyFinder._parse_string(suffix)
-                    if prefix == module and suffix not in direct:
+                    if prefix == module and suffix not in direct and parsed_json['scope'] != 'test':
                         transitive = []
                         trans = []
                         direct.append(suffix)
@@ -79,7 +79,7 @@ class DependencyFinder():
                 line = line.replace(' ;', '')
                 pref, suff = line.strip().split(" -> ")
                 parsed_json = DependencyFinder._parse_string(suff)
-                if pref == suffix and suff not in trans and parsed_json['classifier'] != 'test':
+                if pref == suffix and suff not in trans and parsed_json['scope'] != 'test':
                     trans.append(suff)
                     tmp_json = {
                         "package": parsed_json['groupId'] + ":" + parsed_json['artifactId'],
@@ -110,9 +110,8 @@ class DependencyFinder():
         elif ncolons == 3:
             a['groupId'], a['artifactId'], a['packaging'], a['version'] = coordinates_str.split(':')
         elif ncolons == 4:
-            # Usually, it's groupId:artifactId:packaging:classifier:version but here it's
-            # groupId:artifactId:packaging:version:classifier
-            a['groupId'], a['artifactId'], a['packaging'], a['version'], a['classifier'] = \
+            # groupId:artifactId:packaging:version:scope
+            a['groupId'], a['artifactId'], a['packaging'], a['version'], a['scope'] = \
                 coordinates_str.split(':')
         elif ncolons == 5:
             # groupId:artifactId:packaging:classifier:version:scope

--- a/f8a_utils/dependency_finder.py
+++ b/f8a_utils/dependency_finder.py
@@ -78,9 +78,9 @@ class DependencyFinder():
                 line = line.replace('"', '')
                 line = line.replace(' ;', '')
                 pref, suff = line.strip().split(" -> ")
-                if pref == suffix and suff not in trans:
+                parsed_json = DependencyFinder._parse_string(suff)
+                if pref == suffix and suff not in trans and parsed_json['classifier'] != 'test':
                     trans.append(suff)
-                    parsed_json = DependencyFinder._parse_string(suff)
                     tmp_json = {
                         "package": parsed_json['groupId'] + ":" + parsed_json['artifactId'],
                         "version": parsed_json['version']

--- a/tests/test_depencency_finder.py
+++ b/tests/test_depencency_finder.py
@@ -130,7 +130,7 @@ def test_scan_and_find_dependencies_maven_ignore_test_deps():
             # Actually there are 18 test transitive for package, but we are filtering test packages.
             # So, expect to have '0' transitive deps.
             assert len(resolved['deps']) == 0
-    assert found_package == True
+    assert found_package
 
 
 if __name__ == '__main__':

--- a/tests/test_depencency_finder.py
+++ b/tests/test_depencency_finder.py
@@ -122,15 +122,8 @@ def test_scan_and_find_dependencies_maven_ignore_test_deps():
     }]
     res = DependencyFinder().scan_and_find_dependencies("maven", manifests, "true")
     assert "result" in res
-    # Look for 'io.rest-assured:rest-assured' package, it has '18' test deps.
-    found_package = False
-    for resolved in res['result'][0]['details'][0]['_resolved']:
-        if resolved['package'] == 'io.rest-assured:rest-assured':
-            found_package = True
-            # Actually there are 18 test transitive for package, but we are filtering test packages.
-            # So, expect to have '0' transitive deps.
-            assert len(resolved['deps']) == 0
-    assert found_package
+    # There are total 9 packages, but 4 are non-test packages.
+    assert 4 == len(res['result'][0]['details'][0]['_resolved'])
 
 
 if __name__ == '__main__':

--- a/tests/test_depencency_finder.py
+++ b/tests/test_depencency_finder.py
@@ -122,8 +122,31 @@ def test_scan_and_find_dependencies_maven_ignore_test_deps():
     }]
     res = DependencyFinder().scan_and_find_dependencies("maven", manifests, "true")
     assert "result" in res
-    # There are total 9 packages, but 4 are non-test packages.
+
+    # There are total 9 packages, but 4 are mandatory packages.
     assert 4 == len(res['result'][0]['details'][0]['_resolved'])
+
+    # Packages expected are
+    mandatory_packages = [
+        'io.vertx:vertx-core',
+        'io.vertx:vertx-web',
+        'io.vertx:vertx-health-check',
+        'io.vertx:vertx-web-client'
+    ]
+
+    # Pacakge not expected are
+    test_packages = [
+        'io.vertx:vertx-unit',
+        'junit:junit',
+        'org.assertj:assertj-core',
+        'io.rest-assured:rest-assured',
+        'org.arquillian.cube:arquillian-cube-openshift-starter'
+    ]
+
+    # Check that only non-test packages are present.
+    for package in res['result'][0]['details'][0]['_resolved']:
+        assert package['package'] in mandatory_packages
+        assert package['package'] not in test_packages
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Maven ecosystem dependencies need to ignore test dependencies for destination node in manifest file.

Jira Issue :: https://issues.redhat.com/browse/APPAI-1288

Manifest file used for testing :: 
[dependencies.txt](https://github.com/fabric8-analytics/fabric8-analytics-utils/files/4919040/dependencies.txt)

POM file used for testing ::
[pom.xml.txt](https://github.com/fabric8-analytics/fabric8-analytics-utils/files/4923311/pom.xml.txt)

Package list before changes :: 
[filter-no.json.txt](https://github.com/fabric8-analytics/fabric8-analytics-utils/files/4919044/filter-no.json.txt)

Package list after changes ::
[filter_scope.json.txt](https://github.com/fabric8-analytics/fabric8-analytics-utils/files/4931160/filter_scope.json.txt)

Investigation on Maven dependencies ::
Maven system generates dependencies information with various POM dependencies as per rules in https://maven.apache.org/pom.html, some are optional fields and some are having default value. 'Scope' and 'type' attributes of dependency are optional, but have default value as 'compile' and 'jar'. I have tried various input and output as detailed below:

Sample 1 ::
    <dependency>
      <groupId>org.springframework</groupId>
      <artifactId>spring-messaging</artifactId>
      <version>4.3.7.RELEASE</version>
    </dependency>
will generate "org.springframework:spring-messaging:jar:4.3.7.RELEASE:compile"
in form <group id> : <Artifact Id> : <type> : <version> : <scope>
here type and scope are defaulted to 'jar' and 'compile'

Sample 2 ::
    <dependency>
      <groupId>org.springframework</groupId>
      <artifactId>spring-messaging</artifactId>
      <version>4.3.7.RELEASE</version>
      <scope>test</scope>
    </dependency>
will generate "org.springframework:spring-messaging:jar:4.3.7.RELEASE:test"
in form <group id> : <Artifact Id> : <type> : <version> : <scope>
here type is defaulted to 'jar'

Sample 3 ::
    <dependency>
      <groupId>org.springframework</groupId>
      <artifactId>spring-messaging</artifactId>
      <version>4.3.7.RELEASE</version>
      <classifier>sources</classifier>
    </dependency>
will generate "org.springframework:spring-messaging:jar:sources:4.3.7.RELEASE:compile"
in form <group id> : <Artifact Id> : <type> : <classifier> : <version> : <scope>
here type and scope are defaulted to 'jar' and 'compile'

Sample 4 ::
    <dependency>
      <groupId>org.springframework</groupId>
      <artifactId>spring-messaging</artifactId>
      <version>4.3.7.RELEASE</version>
      <classifier>sources</classifier>
      <scope>test</scope>
    </dependency>
will generate "org.springframework:spring-messaging:jar:sources:4.3.7.RELEASE:test"
in form <group id> : <Artifact Id> : <type> : <classifier> : <version> : <scope>
here type is defaulted to 'jar'




