### PR TITLE
fix: Remove usage of deprecated dependency_links from setup.py

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,3 @@
 lxml
 requests
-git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator
+f8a_version_comparator @ git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def get_requirements():
 install_requires = get_requirements()
 
 setup(
-    name='fabric8-analytics-utils',
+    name='f8a-utils',
     version='0.1.0',
     description='Library containing utilities and helper functions for f8a services',
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -8,24 +8,19 @@ def get_requirements():
     """Parse dependencies from 'requirements.in' file."""
     with open('requirements.in') as fd:
         lines = fd.read().splitlines()
-        requires, links = [], []
+        requires = []
         for line in lines:
-            if line.startswith('git+'):
-                links.append(line)
-            elif line:
-                requires.append(line)
-        return requires, links
+            requires.append(line)
+        return requires
 
 
-install_requires, dependency_links = get_requirements()
-
+install_requires = get_requirements()
 
 setup(
     name='fabric8-analytics-utils',
     version='0.1.0',
     description='Library containing utilities and helper functions for f8a services',
     install_requires=install_requires,
-    dependency_links=dependency_links,
     license='Apache-2.0',
     author='Michal Srb',
     author_email='michal@redhat.com',


### PR DESCRIPTION
### Problem

Transitives of external packages are not downloaded when the problematic package is installed through pip.
e.g.
`pip install git+https://github.com/fabric8-analytics/fabric8-analytics-utils`

### Root cause
The problematic external packages's setup.py uses a deprecated argument which is [no longer considered by pip](https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords).
>dependency_links

> Warning dependency_links is deprecated. It is not supported anymore by pip.
> A list of strings naming URLs to be searched when satisfying dependencies. These links will be used if needed to install packages specified by setup_requires or tests_require. They will also be written into the egg’s metadata for use by tools like >EasyInstall to use when installing an .egg file.

### Solution
External packages can use install_requires

### Log

```
pip install git+https://github.com/arajkumar/fabric8-analytics-utils@remove_dependency_links
Collecting git+https://github.com/arajkumar/fabric8-analytics-utils@remove_dependency_links
  Cloning https://github.com/arajkumar/fabric8-analytics-utils (to revision remove_dependency_links) to /private/var/folders/n_/_62ch8151wl4bdvxttx7nw280000gn/T/pip-req-build-ngvqr0ce
  Running command git clone -q https://github.com/arajkumar/fabric8-analytics-utils /private/var/folders/n_/_62ch8151wl4bdvxttx7nw280000gn/T/pip-req-build-ngvqr0ce
  Running command git checkout -b remove_dependency_links --track origin/remove_dependency_links
  Switched to a new branch 'remove_dependency_links'
  Branch 'remove_dependency_links' set up to track remote branch 'remove_dependency_links' from 'origin'.
Collecting lxml
  Using cached https://files.pythonhosted.org/packages/ad/66/8e3139f8bd3200777c43b508a71cac92c17d96c58fb0117a2ccce3fc3f4a/lxml-4.5.2-cp36-cp36m-macosx_10_9_x86_64.whl
Collecting requests
  Using cached https://files.pythonhosted.org/packages/45/1e/0c169c6a5381e241ba7404532c16a21d86ab872c9bed8bdcd4c423954103/requests-2.24.0-py2.py3-none-any.whl
Collecting f8a_version_comparator@ git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator
  Cloning https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git (to revision 8a57ac7) to /private/var/folders/n_/_62ch8151wl4bdvxttx7nw280000gn/T/pip-install-kaj2i6y1/f8a-version-comparator
  Running command git clone -q https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git /private/var/folders/n_/_62ch8151wl4bdvxttx7nw280000gn/T/pip-install-kaj2i6y1/f8a-version-comparator
  WARNING: Did not find branch or tag '8a57ac7', assuming revision or ref.
  Running command git checkout -q 8a57ac7
Collecting certifi>=2017.4.17
  Using cached https://files.pythonhosted.org/packages/5e/c4/6c4fe722df5343c33226f0b4e0bb042e4dc13483228b4718baf286f86d87/certifi-2020.6.20-py2.py3-none-any.whl
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1
  Using cached https://files.pythonhosted.org/packages/9f/f0/a391d1463ebb1b233795cabfc0ef38d3db4442339de68f847026199e69d7/urllib3-1.25.10-py2.py3-none-any.whl
Collecting idna<3,>=2.5
  Using cached https://files.pythonhosted.org/packages/a2/38/928ddce2273eaa564f6f50de919327bf3a00f091b5baba8dfa9460f3a8a8/idna-2.10-py2.py3-none-any.whl
Collecting chardet<4,>=3.0.2
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Building wheels for collected packages: f8a-utils, f8a-version-comparator
  Building wheel for f8a-utils (setup.py) ... done
  Created wheel for f8a-utils: filename=f8a_utils-0.1.0-cp36-none-any.whl size=10703 sha256=351ad0e437d36976623a7c71313a7e15adaa63946ec4166963d88e9bad7b24c1
  Stored in directory: /private/var/folders/n_/_62ch8151wl4bdvxttx7nw280000gn/T/pip-ephem-wheel-cache-0ognv4d_/wheels/67/b3/11/2d72f7a189149011ec99672804e95a26fd10066c057d12a891
  Building wheel for f8a-version-comparator (setup.py) ... done
  Created wheel for f8a-version-comparator: filename=f8a_version_comparator-0.1-cp36-none-any.whl size=6400 sha256=1169cde4ded92ef7436764f05a3e4286347c4978c8c688586c69519fdd24cf90
  Stored in directory: /private/var/folders/n_/_62ch8151wl4bdvxttx7nw280000gn/T/pip-ephem-wheel-cache-0ognv4d_/wheels/3a/e8/dc/b89149c129de2b6487fc47451390dd75f60fdc391d73d8879a
Successfully built f8a-utils f8a-version-comparator
Installing collected packages: lxml, certifi, urllib3, idna, chardet, requests, f8a-version-comparator, f8a-utils
Successfully installed certifi-2020.6.20 chardet-3.0.4 f8a-utils-0.1.0 f8a-version-comparator-0.1 idna-2.10 lxml-4.5.2 requests-2.24.0 urllib3-1.25.10
WARNING: You are using pip version 19.3.1; however, version 20.2.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

```
fabric8-analytics-utils git:(remove_dependency_links) pip freeze
certifi==2020.6.20
chardet==3.0.4
f8a-utils==0.1.0
f8a-version-comparator==0.1
idna==2.10
lxml==4.5.2
requests==2.24.0
urllib3==1.25.10
```