### PR TITLE
Added support for golang

### DIFF
--- a/f8a_utils/golang_utils.py
+++ b/f8a_utils/golang_utils.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright © 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Author: Yusuf Zainee <yzainee@redhat.com>
+#
+
+"""Utility file to fetch golang details."""
+
+from f8a_utils.web_scraper import Scraper
+import logging
+
+
+_logger = logging.getLogger(__name__)
+
+
+class GolangUtils:
+    """Golang utils class."""
+
+    def __init__(self, pkg):
+        """Init method for GolangUtils class."""
+        self.version_list = []
+        self.mode = None
+        self.latest_version = "-1"
+        self.gh_link = None
+        self.license = None
+        self.url = self.__populate_data(pkg)
+
+    def __fetch_all_versions(self, obj):
+        """Fetch all the versions of a pkg."""
+        ver_list = obj.get_value_from_list('li', 'a', {'class': 'Versions-item'})
+        if len(ver_list) != 0:
+            final_list = []
+            for ver in ver_list:
+                if "+incompatible" in ver:
+                    final_list.append(ver.split('+incompatible')[0])
+                else:
+                    final_list.append(ver)
+            return final_list
+        return ver_list
+
+    def __fetch_latest_version(self, obj):
+        """Fetch the latest version of a pkg."""
+        latest_ver = obj.get_value('div', {'class': 'DetailsHeader-version'})
+        if "+incompatible" in latest_ver:
+            latest_ver = latest_ver.split('+incompatible')[0]
+        return latest_ver
+
+    def __fetch_license(self, obj):
+        """Fetch the github link of a pkg."""
+        return obj.get_value(
+            'a', None, None,
+            obj.get_sub_data('span', {'data-test-id': 'DetailsHeader-infoLabelLicense'}))
+
+    def __fetch_gh_link(self, obj):
+        """Fetch the github link of a pkg."""
+        return obj.get_value(
+            'a', None, 'href',
+            obj.get_sub_data('p', {'class': 'Overview-sourceCodeLink'}))
+
+    def __populate_data(self, pkg):
+        """Set the data for the golang pkg."""
+        _logger.info("Populating the data object for {}".format(pkg))
+        pkg_url = "https://pkg.go.dev/{}".format(pkg)
+        mod_url = "https://pkg.go.dev/mod/{}".format(pkg)
+        scraper = Scraper(pkg_url + "?tab=versions")
+        self.version_list = self.__fetch_all_versions(scraper)
+        if len(self.version_list) == 0:
+            _logger.info("Fetching the details from mod.")
+            scraper = Scraper(mod_url + "?tab=versions")
+            self.version_list = self.__fetch_all_versions(scraper)
+            if len(self.version_list) != 0:
+                self.mode = "mod"
+                self.latest_version = self.__fetch_latest_version(scraper)
+            else:
+                self.mode = "Not Found"
+            return mod_url
+        else:
+            _logger.info("Fetching the details from pkg.")
+            self.mode = "pkg"
+            self.latest_version = self.__fetch_latest_version(scraper)
+            return pkg_url
+
+    def get_all_versions(self):
+        """Return all the versions of a pkg."""
+        if self.mode == "Not Found":
+            return None
+        return self.version_list
+
+    def get_latest_version(self):
+        """Return the latest versions of a pkg."""
+        if self.mode == "Not Found":
+            return None
+        return self.latest_version
+
+    def get_gh_link(self):
+        """Return the gh link of a pkg."""
+        if self.mode == "Not Found":
+            return None
+        if not self.gh_link:
+            if self.mode == "pkg":
+                url = self.url + "?tab=overview"
+            else:
+                url = self.url + "?tab=Overview"
+            scraper_ov = Scraper(url)
+            self.gh_link = self.__fetch_gh_link(scraper_ov)
+            self.license = self.__fetch_license(scraper_ov)
+        return self.gh_link
+
+    def get_license(self):
+        """Return declared license of a pkg."""
+        if self.mode == "Not Found":
+            return None
+        if not self.license:
+            if self.mode == "pkg":
+                url = self.url + "?tab=overview"
+            else:
+                url = self.url + "?tab=Overview"
+            scraper_ov = Scraper(url)
+            self.gh_link = self.__fetch_gh_link(scraper_ov)
+            self.license = self.__fetch_license(scraper_ov)
+        return self.license

--- a/f8a_utils/versions.py
+++ b/f8a_utils/versions.py
@@ -5,6 +5,7 @@ import logging
 from urllib.request import urlopen
 from lxml import etree
 from f8a_version_comparator.comparable_version import ComparableVersion
+from f8a_utils.golang_utils import GolangUtils
 
 _logger = logging.getLogger(__name__)
 
@@ -26,6 +27,8 @@ def get_versions_and_latest_for_ep(ecosystem, package_name):
         return get_versions_for_pypi_package(package_name, dual_values=True)
     if ecosystem == 'maven':
         return get_versions_for_maven_package(package_name, dual_values=True)
+    if ecosystem == 'golang':
+        return get_versions_for_golang_package(package_name, dual_values=True)
     else:
         raise ValueError('Unsupported ecosystem: {e}'.format(e=ecosystem))
 
@@ -47,6 +50,8 @@ def get_versions_for_ep(ecosystem, package_name):
         return get_versions_for_pypi_package(package_name)
     if ecosystem == 'maven':
         return get_versions_for_maven_package(package_name)
+    if ecosystem == 'golang':
+        return get_versions_for_golang_package(package_name)
     else:
         raise ValueError('Unsupported ecosystem: {e}'.format(e=ecosystem))
 
@@ -76,9 +81,30 @@ def get_latest_versions_for_ep(ecosystem, package_name):
         version = get_versions_for_pypi_package(package_name, True)
     elif ecosystem == 'maven':
         version = get_versions_for_maven_package(package_name, True)
+    elif ecosystem == 'golang':
+        version = get_versions_for_golang_package(package_name, True)
     else:
         raise ValueError('Unsupported ecosystem: {e}'.format(e=ecosystem))
     return version
+
+
+def get_versions_for_golang_package(package_name, latest=False, dual_values=False):
+    """Get all versions for given golang package.
+
+    :param package_name: str, package name
+    :param latest: boolean value, to return only the latest version
+    :param dual_values: boolean value, to return both version list and latest version
+    :return list, list of versions
+    """
+    go_util = GolangUtils(package_name)
+    latest_ver = go_util.get_latest_version()
+    all_ver = go_util.get_all_versions()
+    if latest:
+        return latest_ver
+    if dual_values:
+        return {'versions': all_ver,
+                'latest_version': latest_ver}
+    return all_ver
 
 
 def get_versions_for_npm_package(package_name, latest=False, dual_values=False):

--- a/f8a_utils/web_scraper.py
+++ b/f8a_utils/web_scraper.py
@@ -73,7 +73,7 @@ class Scraper:
 
 
 """
-This code is kept commented with purpose: If anyone wants to try out scraper. 
+This code is kept commented with purpose: If anyone wants to try out scraper.
 Its easier to follow these examples
 if __name__ == '__main__':
 
@@ -88,11 +88,11 @@ if __name__ == '__main__':
     scraper = Scraper(url)
     print("--gh link--")
     print(scraper.get_value(
-        'a', None, 'href', 
+        'a', None, 'href',
         scraper.get_sub_data('p', {'class': 'Overview-sourceCodeLink'})))
     print("--license--")
     print(scraper.get_value(
-        'a', None, None, 
+        'a', None, None,
         scraper.get_sub_data('span', {'data-test-id': 'DetailsHeader-infoLabelLicense'})))
 
     url = "https://pkg.go.dev/mod/k8s.io/kubelet?tab=versions"
@@ -106,11 +106,11 @@ if __name__ == '__main__':
     scraper = Scraper(url)
     print("--gh link--")
     print(scraper.get_value(
-        'a', None, 'href', 
+        'a', None, 'href',
         scraper.get_sub_data('p', {'class': 'Overview-sourceCodeLink'})))
     print("--license--")
     print(scraper.get_value(
-        'a', None, None, 
+        'a', None, None,
         scraper.get_sub_data('span', {'data-test-id': 'DetailsHeader-infoLabelLicense'})))
 
     url = "https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-core"

--- a/f8a_utils/web_scraper.py
+++ b/f8a_utils/web_scraper.py
@@ -73,7 +73,8 @@ class Scraper:
 
 
 """
-This code is kept commented with purpose: If anyone wants to try out scraper, its easier to follow these examples
+This code is kept commented with purpose: If anyone wants to try out scraper. 
+Its easier to follow these examples
 if __name__ == '__main__':
 
     url = "https://pkg.go.dev/github.com/kubernetes/kubernetes/pkg/volume/scaleio?tab=versions"
@@ -83,12 +84,16 @@ if __name__ == '__main__':
     print("--latest--")
     print(scraper.get_value('div', {'class': 'DetailsHeader-version'}))
 
-    url = "https://pkg.go.dev/github.com/kubernetes/kubernetes/pkg/volume/scaleio?tab=overview" #Overview for mod
+    url = "https://pkg.go.dev/github.com/kubernetes/kubernetes/pkg/volume/scaleio?tab=overview"
     scraper = Scraper(url)
     print("--gh link--")
-    print(scraper.get_value('a', None, 'href', scraper.get_sub_data('p', {'class': 'Overview-sourceCodeLink'})))
+    print(scraper.get_value(
+        'a', None, 'href', 
+        scraper.get_sub_data('p', {'class': 'Overview-sourceCodeLink'})))
     print("--license--")
-    print(scraper.get_value('a', None, None, scraper.get_sub_data('span', {'data-test-id': 'DetailsHeader-infoLabelLicense'})))
+    print(scraper.get_value(
+        'a', None, None, 
+        scraper.get_sub_data('span', {'data-test-id': 'DetailsHeader-infoLabelLicense'})))
 
     url = "https://pkg.go.dev/mod/k8s.io/kubelet?tab=versions"
     scraper = Scraper(url)
@@ -100,9 +105,13 @@ if __name__ == '__main__':
     url = "https://pkg.go.dev/mod/github.com/Rican7/retry?tab=Overview" #Overview for mod
     scraper = Scraper(url)
     print("--gh link--")
-    print(scraper.get_value('a', None, 'href', scraper.get_sub_data('p', {'class': 'Overview-sourceCodeLink'})))
+    print(scraper.get_value(
+        'a', None, 'href', 
+        scraper.get_sub_data('p', {'class': 'Overview-sourceCodeLink'})))
     print("--license--")
-    print(scraper.get_value('a', None, None, scraper.get_sub_data('span', {'data-test-id': 'DetailsHeader-infoLabelLicense'})))
+    print(scraper.get_value(
+        'a', None, None, 
+        scraper.get_sub_data('span', {'data-test-id': 'DetailsHeader-infoLabelLicense'})))
 
     url = "https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-core"
     scraper = Scraper(url)

--- a/f8a_utils/web_scraper.py
+++ b/f8a_utils/web_scraper.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright © 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Author: Yusuf Zainee <yzainee@redhat.com>
+#
+
+"""Functionality to fetch details from HTML pages."""
+
+
+from bs4 import BeautifulSoup
+import requests
+
+
+class Scraper:
+    """Scraper class to fetch data from HTML."""
+
+    def __init__(self, url):
+        """Init method for Scraper class."""
+        html_content = requests.get(url).text
+        self.DATA = BeautifulSoup(html_content, "lxml")
+
+    def get_data(self):
+        """Get data function to return the entire content."""
+        return self.DATA
+
+    def get_sub_data(self, tag, attrs=None, obj=None):
+        """Fetch the sub object of a tag from HTML content."""
+        if not obj:
+            obj = self.DATA
+        return obj.find(tag, attrs=attrs)
+
+    def get_value(self, tag, attrs=None, param=None, obj=None):
+        """Fetch the text value or param value of a tag from HTML content."""
+        if not obj:
+            obj = self.DATA
+        if not param:
+            val = obj.find(tag, attrs=attrs).text
+        else:
+            val = obj.find(tag, attrs=attrs)[param]
+        return val
+
+    def get_list(self, tag, attrs=None, obj=None):
+        """Fetch the details and return a list."""
+        if not obj:
+            obj = self.DATA
+        return obj.find_all(tag, attrs=attrs)
+
+    def get_value_from_list(self, list_tag, data_tag, list_attrs=None,
+                            data_attrs=None, param=None, obj=None):
+        """Fetch the value from inside the list items."""
+        list_data = self.get_list(list_tag, list_attrs, obj)
+        results = []
+        for li in list_data:
+            if data_tag:
+                results.append(self.get_value(data_tag, data_attrs, param, li))
+            else:
+                if param:
+                    results.append(li[param])
+                else:
+                    results.append(li.text)
+        return results
+
+
+"""
+This code is kept commented with purpose: If anyone wants to try out scraper, its easier to follow these examples
+if __name__ == '__main__':
+
+    url = "https://pkg.go.dev/github.com/kubernetes/kubernetes/pkg/volume/scaleio?tab=versions"
+    scraper = Scraper(url)
+    print("--all--")
+    print(scraper.get_value_from_list('li', 'a', {'class': 'Versions-item'}))
+    print("--latest--")
+    print(scraper.get_value('div', {'class': 'DetailsHeader-version'}))
+
+    url = "https://pkg.go.dev/github.com/kubernetes/kubernetes/pkg/volume/scaleio?tab=overview" #Overview for mod
+    scraper = Scraper(url)
+    print("--gh link--")
+    print(scraper.get_value('a', None, 'href', scraper.get_sub_data('p', {'class': 'Overview-sourceCodeLink'})))
+    print("--license--")
+    print(scraper.get_value('a', None, None, scraper.get_sub_data('span', {'data-test-id': 'DetailsHeader-infoLabelLicense'})))
+
+    url = "https://pkg.go.dev/mod/k8s.io/kubelet?tab=versions"
+    scraper = Scraper(url)
+    print("--all--")
+    print(scraper.get_value_from_list('li', 'a', {'class': 'Versions-item'}))
+    print("--latest--")
+    print(scraper.get_value('div', {'class': 'DetailsHeader-version'}))
+
+    url = "https://pkg.go.dev/mod/github.com/Rican7/retry?tab=Overview" #Overview for mod
+    scraper = Scraper(url)
+    print("--gh link--")
+    print(scraper.get_value('a', None, 'href', scraper.get_sub_data('p', {'class': 'Overview-sourceCodeLink'})))
+    print("--license--")
+    print(scraper.get_value('a', None, None, scraper.get_sub_data('span', {'data-test-id': 'DetailsHeader-infoLabelLicense'})))
+
+    url = "https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-core"
+    scraper = Scraper(url)
+    print("--versions--")
+    print(scraper.get_value_from_list('a', None, {'class': 'vbtn release'}, None, 'href'))
+"""

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 lxml
 requests
+bs4
 f8a_version_comparator @ git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,6 +5,8 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 attrs==19.3.0             # via pytest
+beautifulsoup4==4.9.1     # via bs4
+bs4==0.0.1                # via -r ../requirements.in
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 codecov==2.1.8            # via -r requirements.in
@@ -22,6 +24,7 @@ pytest-cov==2.10.0        # via -r requirements.in
 pytest==5.4.3             # via -r requirements.in, pytest-cov
 requests==2.24.0          # via -r ../requirements.in, codecov
 six==1.15.0               # via packaging
+soupsieve==2.0.1          # via beautifulsoup4
 urllib3==1.25.9           # via requests
 wcwidth==0.2.5            # via pytest
 zipp==3.1.0               # via importlib-metadata

--- a/tests/test_golang_utils.py
+++ b/tests/test_golang_utils.py
@@ -1,0 +1,43 @@
+"""Test file for all the golang utils functions."""
+
+from f8a_utils.golang_utils import GolangUtils
+
+
+def test_golang_utils_with_valid_pkg():
+    """Test golang functions with a valid pkg."""
+    go_obj = GolangUtils("github.com/grafana/grafana")
+    assert go_obj.mode == "mod"
+    assert "v6.1.4" in go_obj.get_all_versions()
+    assert go_obj.get_latest_version() is not None
+    assert go_obj.get_gh_link() == "https://github.com/grafana/grafana"
+    assert go_obj.get_license() == "Apache-2.0"
+
+    go_obj = GolangUtils("k8s.io/kubelet")
+    assert go_obj.mode == "mod"
+    assert go_obj.get_license() == "Apache-2.0"
+    assert go_obj.get_gh_link() == "https://github.com/kubernetes/kubelet"
+
+
+def test_golang_utils_with_valid_pkg2():
+    """Test golang functions with a valid pkg."""
+    go_obj = GolangUtils("github.com/containous/traefik/api")
+    assert go_obj.mode == "pkg"
+    assert "v1.7.26" in go_obj.get_all_versions()
+    assert go_obj.get_latest_version() is not None
+    assert go_obj.get_license() == "MIT"
+    assert go_obj.get_gh_link() == "https://github.com/containous/traefik"
+
+    go_obj = GolangUtils("github.com/ryanuber/columnize")
+    assert go_obj.mode == "pkg"
+    assert go_obj.get_gh_link() == "https://github.com/ryanuber/columnize"
+    assert go_obj.get_license() == "MIT"
+
+
+def test_golang_utils_with_invalid_pkg():
+    """Test golang functions with a invalid pkg."""
+    go_obj = GolangUtils("some_junk_name")
+    assert go_obj.mode == "Not Found"
+    assert not go_obj.get_all_versions()
+    assert not go_obj.get_latest_version()
+    assert not go_obj.get_gh_link()
+    assert not go_obj.get_license()

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -11,7 +11,8 @@ from f8a_utils.versions import (
     get_latest_versions_for_ep,
     is_pkg_public,
     get_versions_and_latest_for_ep,
-    select_latest_version
+    select_latest_version,
+    get_versions_for_golang_package
 )
 
 
@@ -51,6 +52,11 @@ def test_get_versions_and_latest_for_ep():
     obj = get_versions_and_latest_for_ep("maven", "tomcat:catalina")
     assert obj['versions'] is not None
     assert "4.0.4" in obj['versions']
+    assert obj['latest_version'] is not None
+
+    obj = get_versions_and_latest_for_ep("golang", "github.com/grafana/grafana")
+    assert obj['versions'] is not None
+    assert "v6.1.6" in obj['versions']
     assert obj['latest_version'] is not None
 
     with pytest.raises(ValueError):
@@ -142,6 +148,19 @@ def test_get_javascript_versions_server_response_without_json(_mocked_get):
     assert not package_versions
 
 
+def test_get_golang_versions():
+    """Test basic behavior of function get_versions_for_golang_package."""
+    versions = get_versions_for_golang_package("github.com/grafana/grafana")
+    assert versions is not None
+
+    versions = get_versions_for_golang_package("some_junk_name")
+    assert versions is None
+
+    versions = get_versions_for_ep("golang", "github.com/grafana/grafana")
+    assert versions is not None
+    assert "v6.1.6" in versions
+
+
 def test_get_python_versions():
     """Test basic behavior of function get_versions_for_pypi_package."""
     package_versions = get_versions_for_pypi_package("numpy")
@@ -228,6 +247,12 @@ def test_get_latest_versions_for_ep():
 
     package_versions = get_latest_versions_for_ep("npm", "lerna-tt-pk2-sy")
     assert package_versions is not None
+
+    package_versions = get_latest_versions_for_ep("golang", "github.com/grafana/grafana")
+    assert package_versions is not None
+
+    package_versions = get_latest_versions_for_ep("golang", "no_such_pkg_exist")
+    assert not package_versions
 
     package_versions = get_latest_versions_for_ep("npm", "abyzdeopkl")
     assert not package_versions


### PR DESCRIPTION
Added golang support.
As golang doesnt have any pkg manager nor does it have any built in API support, we had to rely on web scraping to get all the golang related information.
Webscraping can be used for other ecosystems or also for getting info on unknown pkgs like few in maven who are not present in the central system