### PR TITLE
removed v from versions of golang

### DIFF
--- a/f8a_utils/golang_utils.py
+++ b/f8a_utils/golang_utils.py
@@ -43,9 +43,18 @@ class GolangUtils:
             final_list = []
             for ver in ver_list:
                 if "+incompatible" in ver:
-                    final_list.append(ver.split('+incompatible')[0])
+                    intermediate_value = ver.split('+incompatible')[0]
+                    if "v" in intermediate_value:
+                        version = intermediate_value.split('v')[1]
+                    else:
+                        version = intermediate_value
+                    final_list.append(version)
                 else:
-                    final_list.append(ver)
+                    if "v" in ver:
+                        version = ver.split('v')[1]
+                    else:
+                        version = ver
+                    final_list.append(version)
             return final_list
         return ver_list
 
@@ -53,7 +62,14 @@ class GolangUtils:
         """Fetch the latest version of a pkg."""
         latest_ver = obj.get_value('div', {'class': 'DetailsHeader-version'})
         if "+incompatible" in latest_ver:
-            latest_ver = latest_ver.split('+incompatible')[0]
+            intermediate_value = latest_ver.split('+incompatible')[0]
+            if "v" in intermediate_value:
+                latest_ver = intermediate_value.split('v')[1]
+            else:
+                latest_ver = intermediate_value
+        else:
+            if "v" in latest_ver:
+                latest_ver = latest_ver.split('v')[1]
         return latest_ver
 
     def __fetch_license(self, obj):

--- a/tests/test_golang_utils.py
+++ b/tests/test_golang_utils.py
@@ -7,7 +7,8 @@ def test_golang_utils_with_valid_pkg():
     """Test golang functions with a valid pkg."""
     go_obj = GolangUtils("github.com/grafana/grafana")
     assert go_obj.mode == "mod"
-    assert "v6.1.4" in go_obj.get_all_versions()
+    assert "6.1.4" in go_obj.get_all_versions()
+    assert "v6.1.4" not in go_obj.get_all_versions()
     assert go_obj.get_latest_version() is not None
     assert go_obj.get_gh_link() == "https://github.com/grafana/grafana"
     assert go_obj.get_license() == "Apache-2.0"
@@ -22,7 +23,7 @@ def test_golang_utils_with_valid_pkg2():
     """Test golang functions with a valid pkg."""
     go_obj = GolangUtils("github.com/containous/traefik/api")
     assert go_obj.mode == "pkg"
-    assert "v1.7.26" in go_obj.get_all_versions()
+    assert "1.7.26" in go_obj.get_all_versions()
     assert go_obj.get_latest_version() is not None
     assert go_obj.get_license() == "MIT"
     assert go_obj.get_gh_link() == "https://github.com/containous/traefik"

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -56,7 +56,7 @@ def test_get_versions_and_latest_for_ep():
 
     obj = get_versions_and_latest_for_ep("golang", "github.com/grafana/grafana")
     assert obj['versions'] is not None
-    assert "v6.1.6" in obj['versions']
+    assert "6.1.6" in obj['versions']
     assert obj['latest_version'] is not None
 
     with pytest.raises(ValueError):
@@ -158,7 +158,7 @@ def test_get_golang_versions():
 
     versions = get_versions_for_ep("golang", "github.com/grafana/grafana")
     assert versions is not None
-    assert "v6.1.6" in versions
+    assert "6.1.6" in versions
 
 
 def test_get_python_versions():


### PR DESCRIPTION
Versions in golang in the html page include the value 'v' in front. Problem is that snyk feed doesnt identify v in the version and also the version comparator fails to identify the version with v. Hence universally removing the value 'v' from versions