### PR TITLE
Common functions to check for pseudo version and extract timestamp from version

### DIFF
--- a/f8a_utils/gh_utils.py
+++ b/f8a_utils/gh_utils.py
@@ -259,7 +259,7 @@ class GithubUtils:
         else:
             return self.__check_for_date_rule(comm_date, date_range_rules)
 
-    def _is_pseudo_version(self, pseudo_version):
+    def is_pseudo_version(self, pseudo_version):
         """Check if given version is a pseudo version.
 
         :param version: str - Package version.
@@ -269,7 +269,7 @@ class GithubUtils:
         # Example :: v0.0.0-20200410000936-a663fba25f7a
         return len(re.findall(r'\d.\d.\d-\d{14}-[0-9a-zA-Z]{12}', pseudo_version)) == 1
 
-    def _extract_timestamp(self, pseudo_version: str):
+    def extract_timestamp(self, pseudo_version: str):
         """Extract timestamp value YYYYMMDDHHMMSS from given string."""
         # Example :: v0.0.0-20200410000936-a663fba25f7a
         timestamp = re.findall(r'\d{14}', pseudo_version)

--- a/f8a_utils/gh_utils.py
+++ b/f8a_utils/gh_utils.py
@@ -17,6 +17,7 @@
 
 """Utility file to fetch github details."""
 
+import re
 import random
 import logging
 import requests
@@ -257,3 +258,22 @@ class GithubUtils:
             return False
         else:
             return self.__check_for_date_rule(comm_date, date_range_rules)
+
+    def _is_pseudo_version(self, pseudo_version):
+        """Check if given version is a pseudo version.
+
+        :param version: str - Package version.
+        :return: True is its pseudo version for golang otherwise False.
+        """
+        # Pseudo if contains semver followed by 14 digit timestamp and 12 digits commit hash.
+        # Example :: v0.0.0-20200410000936-a663fba25f7a
+        return len(re.findall(r'\d.\d.\d-\d{14}-[0-9a-zA-Z]{12}', pseudo_version)) == 1
+
+    def _extract_timestamp(self, pseudo_version: str):
+        """Extract timestamp value YYYYMMDDHHMMSS from given string."""
+        # Example :: v0.0.0-20200410000936-a663fba25f7a
+        timestamp = re.findall(r'\d{14}', pseudo_version)
+        if len(timestamp) > 0:
+            return str(timestamp[0])
+
+        return None

--- a/tests/test_gh_utils.py
+++ b/tests/test_gh_utils.py
@@ -142,7 +142,7 @@ def test_is_commit_date_in_vuln_range():
 
 
 def test_is_pseudo_version():
-    """Test _is_pseudo_version."""
+    """Test is_pseudo_version."""
     test_data = {
         "1.3.4": False,
         "v2.3.7": False,
@@ -162,12 +162,12 @@ def test_is_pseudo_version():
 
     gh = GithubUtils()
     for version, expected_value in test_data.items():
-        res = gh._is_pseudo_version(version)
+        res = gh.is_pseudo_version(version)
         assert res == expected_value, f"For {version} expected value: {expected_value}"
 
 
 def test_extract_timestamp():
-    """Test _extract_timestamp."""
+    """Test extract_timestamp."""
     test_data = {
         "1.3.4": None,
         "v2.3.7": None,
@@ -187,5 +187,5 @@ def test_extract_timestamp():
 
     gh = GithubUtils()
     for version, expected_value in test_data.items():
-        res = gh._extract_timestamp(version)
+        res = gh.extract_timestamp(version)
         assert res == expected_value, f"For {version} expected value: {expected_value}"

--- a/tests/test_gh_utils.py
+++ b/tests/test_gh_utils.py
@@ -139,3 +139,53 @@ def test_is_commit_date_in_vuln_range():
 
     res = gh._is_commit_date_in_vuln_range("0d4799964558", "*")
     assert res is None
+
+
+def test_is_pseudo_version():
+    """Test _is_pseudo_version."""
+    test_data = {
+        "1.3.4": False,
+        "v2.3.7": False,
+        "1.3.4-alpha": False,
+        "v.4.3.2-alpha": False,
+        "v2.5.4+incompatible": False,
+        "v0.0.0-20201010233445-abcd4321dcba": True,
+        "0.0.0-20201010233445-abcd4321dcba": True,
+        "20201010233445-abcd4321dcba": False,
+        "v0.0.0-20201010233445abcd4321dcba": False,
+        "v0.0.0-20201010233445-abcd4321": False,
+        "v0.0.0-202010102345-abcd4321dcba": False,
+        "v0.0.0-20201010233445-abcd4321dcba-alpha3.4": True,
+        "v0.0.0-20201010233445-abcd4321dcba+incompatible": True,
+        "v0.0.0-abcd4321dcba-20201010233445": False
+    }
+
+    gh = GithubUtils()
+    for version, expected_value in test_data.items():
+        res = gh._is_pseudo_version(version)
+        assert res == expected_value, f"For {version} expected value: {expected_value}"
+
+
+def test_extract_timestamp():
+    """Test _extract_timestamp."""
+    test_data = {
+        "1.3.4": None,
+        "v2.3.7": None,
+        "1.3.4-alpha": None,
+        "v.4.3.2-alpha": None,
+        "v2.5.4+incompatible": None,
+        "v0.0.0-20201010233445-abcd4321dcba": "20201010233445",
+        "0.0.0-20201010233445-abcd4321dcba": "20201010233445",
+        "20201010233445-abcd4321dcba": "20201010233445",
+        "v0.0.0-20201010233445abcd4321dcba": "20201010233445",
+        "v0.0.0-20201010233445-abcd4321": "20201010233445",
+        "v0.0.0-202010102345-abcd4321dcba": None,
+        "v0.0.0-20201010233445-abcd4321dcba-alpha3.4": "20201010233445",
+        "v0.0.0-20201010233445-abcd4321dcba+incompatible": "20201010233445",
+        "v0.0.0-abcd4321dcba-20201010233445": "20201010233445",
+    }
+
+    gh = GithubUtils()
+    for version, expected_value in test_data.items():
+        res = gh._extract_timestamp(version)
+        assert res == expected_value, f"For {version} expected value: {expected_value}"


### PR DESCRIPTION
Added common function to check if given package version is a pseudo version and to extract timestamp value from the pseudo version. This functions are used by API and backbone server while processing CA and SA request for goalng ecosystem.

Jira Ticket :: https://issues.redhat.com/browse/APPAI-1541