### PR TITLE
fix: Use to auth free ingestion endpoint

### DIFF
--- a/f8a_utils/ingestion_utils.py
+++ b/f8a_utils/ingestion_utils.py
@@ -8,11 +8,10 @@ from requests_futures.sessions import FuturesSession
 
 logger = logging.getLogger(__name__)
 
-_APP_SECRET_KEY = os.getenv('APP_SECRET_KEY', 'not-set')
 _INGESTION_API_URL = "http://{host}:{port}/{endpoint}".format(
     host=os.environ.get("INGESTION_SERVICE_HOST", "bayesian-jobs"),
     port=os.environ.get("INGESTION_SERVICE_PORT", "34000"),
-    endpoint='ingestions/epv')
+    endpoint='internal/ingestions/epv')
 _session = FuturesSession()
 Package = namedtuple("Package", ["package", "version"])
 
@@ -31,7 +30,8 @@ def unknown_package_flow(ecosystem: str, unknown_pkgs: Set[namedtuple]):
         "ecosystem": ecosystem,
         "packages": [],
         "force": False,
-        "force_graph_sync": True
+        "force_graph_sync": True,
+        "source": "api"
     }
 
     # Set the unknown packages and versions
@@ -42,9 +42,7 @@ def unknown_package_flow(ecosystem: str, unknown_pkgs: Set[namedtuple]):
     # If package list is not empty then call ingestion API
     if payload['packages']:
         try:
-            _session.post(url=_INGESTION_API_URL,
-                          json=payload,
-                          headers={'auth_token': _APP_SECRET_KEY})
+            _session.post(url=_INGESTION_API_URL, json=payload)
         except Exception as e:
             logger.error('Failed to trigger unknown flow for payload %s with error %s',
                          payload, e)


### PR DESCRIPTION
# Description 

Using auth free ingestion endpoints exposed by Jobs APIs and updated payload to add an optional parameter required by API to identify the consumer of API.  